### PR TITLE
Basic implementation for Discord webhook integration

### DIFF
--- a/code/__DEFINES/server_tools.dm
+++ b/code/__DEFINES/server_tools.dm
@@ -61,6 +61,8 @@
 #define SERVER_TOOLS_CHAT_BROADCAST(message) world.ChatBroadcast(message)
 //Sends a message to connected admin chats
 #define SERVER_TOOLS_RELAY_BROADCAST(message) world.AdminBroadcast(message)
+//Sends a message to a discord webhook
+#define SERVER_TOOLS_DISCORD_WEBHOOK_BROADCAST(message) world.DiscordBroadcast(message)
 
 //IMPLEMENTATION
 
@@ -103,24 +105,24 @@ The MIT License
 
 Copyright (c) 2011 Dominic Tarr
 
-Permission is hereby granted, free of charge, 
-to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to 
-deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, 
-merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom 
-the Software is furnished to do so, 
+Permission is hereby granted, free of charge,
+to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to
+deal in the Software without restriction, including
+without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom
+the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice 
+The above copyright notice and this permission notice
 shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
-ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/code/controllers/configuration/entries/config.dm
+++ b/code/controllers/configuration/entries/config.dm
@@ -348,6 +348,10 @@ CONFIG_DEF(number/error_msg_delay)	// How long to wait between messaging admins 
 	value = 50
 
 CONFIG_DEF(flag/irc_announce_new_game)
+CONFIG_DEF(flag/discord_announce_new_game)
+
+CONFIG_DEF(string/discord_webhook_script_address)
+	value = "localhost:4130"
 
 CONFIG_DEF(flag/debug_admin_hrefs)
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -140,6 +140,8 @@ SUBSYSTEM_DEF(ticker)
 			to_chat(world, "<span class='boldnotice'>Welcome to [station_name()]!</span>")
 			if(CONFIG_GET(flag/irc_announce_new_game))
 				SERVER_TOOLS_CHAT_BROADCAST("New round starting on [SSmapping.config.map_name]!")
+			if(CONFIG_GET(flag/discord_announce_new_game))
+				SERVER_TOOLS_DISCORD_WEBHOOK_BROADCAST("New round starting on [SSmapping.config.map_name]!")
 			current_state = GAME_STATE_PREGAME
 			//Everyone who wants to be an observer is now spawned
 			create_observers()

--- a/code/modules/server_tools/st_interface.dm
+++ b/code/modules/server_tools/st_interface.dm
@@ -99,29 +99,33 @@ SERVER_TOOLS_DEFINE_AND_SET_GLOBAL(server_tools_api_compatible, FALSE)
 				return istext(custom_command_result) ? custom_command_result : "SUCCESS"
 			return "Unknown command: [command]"
 
+/world/proc/DiscordBroadcast(message)
+	// TODO: error handling
+	world.Export("http://[CONFIG_GET(string/discord_webhook_script_address)]/broadcast?msg=[url_encode(message)]")
+
 /*
 The MIT License
 
 Copyright (c) 2011 Dominic Tarr
 
-Permission is hereby granted, free of charge, 
-to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to 
-deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, 
-merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom 
-the Software is furnished to do so, 
+Permission is hereby granted, free of charge,
+to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to
+deal in the Software without restriction, including
+without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom
+the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice 
+The above copyright notice and this permission notice
 shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
-ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */

--- a/config/config.txt
+++ b/config/config.txt
@@ -366,6 +366,12 @@ MINUTE_TOPIC_LIMIT 100
 ## Send a message to IRC when starting a new game
 #IRC_ANNOUNCE_NEW_GAME
 
+## Send a message to a Discord webhook when starting a new game
+#DISCORD_ANNOUNCE_NEW_GAME
+
+## Address the Discord webhook script (tools/discord_webhook_helper/) is listening to
+#DISCORD_WEBHOOK_SCRIPT_ADDRESS localhost:4130
+
 ## Allow admin hrefs that don't use the new token system, will eventually be removed
 DEBUG_ADMIN_HREFS
 

--- a/tools/discord_webhook_helper/README.md
+++ b/tools/discord_webhook_helper/README.md
@@ -1,0 +1,6 @@
+#Usage
+
+1. Build the helper script using the Go toolchain. It doesn't require any external libraries.
+2. Set up a webhook on the Discord channel you wish to post events to.
+3. Run the script as `./discord_webhook_helper [webhook ID] [webhook token] [listen address]`.
+4. Edit `config.txt` accordingly.

--- a/tools/discord_webhook_helper/discord_webhook_helper.go
+++ b/tools/discord_webhook_helper/discord_webhook_helper.go
@@ -1,0 +1,56 @@
+// Space Station 13 Discord webhook integration helper script
+// by Difarem
+
+package main
+
+import (
+	"fmt"
+	"github.com/bwmarrin/discordgo"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 4 {
+		fmt.Printf("Usage: %s [webhook ID] [webhook token] [listen address]\n", os.Args[0])
+		os.Exit(1)
+	}
+	id := os.Args[1]
+	token := os.Args[2]
+	addr := os.Args[3]
+
+	dg, err := discordgo.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/broadcast", func(w http.ResponseWriter, req *http.Request) {
+		err := req.ParseForm()
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if msg, ok := req.Form["msg"]; ok {
+			var params discordgo.WebhookParams
+			params.Content = msg[0]
+
+			// send the message via the webhook
+			err := dg.WebhookExecute(id, token, false, &params)
+			if err != nil {
+				// something went wrong when sending the message
+				log.Println(err)
+				w.WriteHeader(http.StatusInternalServerError)
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	})
+
+	// listen for incoming connections from the BYOND server
+	log.Fatal(http.ListenAndServe(addr, mux))
+}


### PR DESCRIPTION
requires an external helper script (tools/discord_webhook_helper) to be ran alongside the server