### PR TITLE
Adds Credit Score Item + Fixes Bluespace Butt Tech Reqs

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -8,6 +8,27 @@ GAS ANALYZER
 MASS SPECTROMETER
 
 */
+
+/obj/item/device/credit_score
+	name = "\improper Credit Score"
+	icon_state = "signaller"
+	item_state = "signaler"
+	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
+	icon = 'icons/obj/assemblies/new_assemblies.dmi'
+	desc = "A handy little doodad that displays your current credit score. \
+	It's usually somewhere between 450 and 850."
+	w_class = WEIGHT_CLASS_TINY
+	item_state = "electronic"
+	materials = list(MAT_METAL=50)
+	origin_tech = "magnets=1;engineering=1"
+
+/obj/item/device/credit_score/attack_self(mob/user)
+	to_chat(user, "<span class='notice'>Your current credit score is valued at: 720.</span>")
+
+
+
+
 /obj/item/device/t_scanner
 	name = "\improper T-ray scanner"
 	desc = "A terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -93,6 +93,7 @@
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 	new /obj/item/poster/random_contraband(src)
 	new /obj/item/poster/random_official(src)
+	new /obj/item/device/credit_score(src)
 
 /obj/item/storage/box/survival/radio/PopulateContents()
 	..() // we want the survival stuff too.
@@ -105,6 +106,7 @@
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 	new /obj/item/poster/random_contraband(src)
 	new /obj/item/poster/random_official(src)
+	new /obj/item/device/credit_score(src)
 
 
 // Engineer survival box
@@ -114,6 +116,7 @@
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 	new /obj/item/poster/random_contraband(src)
 	new /obj/item/poster/random_official(src)
+	new /obj/item/device/credit_score(src)
 
 /obj/item/storage/box/engineer/radio/PopulateContents()
 	..() // we want the regular items too.
@@ -131,6 +134,7 @@
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 	new /obj/item/poster/random_contraband(src)
 	new /obj/item/poster/random_official(src)
+	new /obj/item/device/credit_score(src)
 
 /obj/item/storage/box/security/radio/PopulateContents()
 	..() // we want the regular stuff too

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -317,6 +317,7 @@ other types of metals and chemistry for reagents).
 	name = "Butt Of Holding"
 	desc = "This butt has bluespace properties, letting you store more items in it. Four tiny items, or two small ones, or one normal one can fit."
 	id = "bluebutt"
+	req_tech = list("bluespace" = 5, "materials" = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD = 500, MAT_SILVER = 500) //quite cheap, for more convenience
 	build_path = /obj/item/organ/butt/bluebutt


### PR DESCRIPTION
Adds the Credit Score device in every starter box for funny bowman memes in conjunction with butt code. 

Adds RnD level requirements for the bluespace butt.